### PR TITLE
Support HEAD requests

### DIFF
--- a/simplejobfiles/app.py
+++ b/simplejobfiles/app.py
@@ -2,7 +2,9 @@ from os import environ, makedirs
 from os.path import (
     dirname,
     exists,
+    getsize,
 )
+from urllib.parse import unquote
 
 # Too big a dependency for just this...
 from galaxy.util import in_directory
@@ -31,6 +33,8 @@ class JobFilesApp:
             resp = self._post(req, params)
         elif method == "GET":
             resp = self._get(req, params)
+        elif method == "HEAD":
+            resp = self._head(req, params)
         else:
             raise Exception("Unhandled request method %s" % method)
         return resp(environ, start_response)
@@ -53,6 +57,15 @@ class JobFilesApp:
             raise AssertionError("{} not in {}".format(path, self.root_directory))
         self.served_files.append(path)
         return _file_response(path)
+
+    def _head(self, request, params):
+        path = unquote(params['path'])
+        if path in self.served_files and not self.allow_multiple_downloads:
+            # emulate Galaxy not allowing the same request twice...
+            raise Exception("Same file copied multiple times...")
+        if not in_directory(path, self.root_directory):
+            raise AssertionError("{} not in {}".format(path, self.root_directory))
+        return _file_header(path)
 
 
 def _copy_to_path(object, path):
@@ -78,6 +91,15 @@ def _file_response(path):
     resp = Response()
     if exists(path):
         resp.app_iter = _FileIterator(path)
+    else:
+        raise exc.HTTPNotFound("No file found with path %s." % path)
+    return resp
+
+
+def _file_header(path):
+    resp = Response()
+    if exists(path):
+        resp.content_length = getsize(path)
     else:
         raise exc.HTTPNotFound("No file found with path %s." % path)
     return resp


### PR DESCRIPTION
Answer requests using the HEAD request method. Include the content length in the answers.

This is a follow up PR for https://github.com/galaxyproject/pulsar/pull/401 (so that integration tests work, because ARC sends HEAD requests to the files server to find out whether files exist).