### PR TITLE
Support PUT requests

### DIFF
--- a/simplejobfiles/app.py
+++ b/simplejobfiles/app.py
@@ -3,6 +3,7 @@ from os.path import (
     dirname,
     exists,
 )
+from urllib.parse import unquote, urljoin
 
 # Too big a dependency for just this...
 from galaxy.util import in_directory
@@ -29,6 +30,8 @@ class JobFilesApp:
         method = req.method
         if method == "POST":
             resp = self._post(req, params)
+        elif method == "PUT":
+            resp = self._put(req, params)
         elif method == "GET":
             resp = self._get(req, params)
         else:
@@ -53,6 +56,16 @@ class JobFilesApp:
             raise AssertionError("{} not in {}".format(path, self.root_directory))
         self.served_files.append(path)
         return _file_response(path)
+
+    def _put(self, request, params):
+        path = unquote(params['path'])
+        if not in_directory(path, self.root_directory):
+            raise AssertionError("{} not in {}".format(path, self.root_directory))
+        parent_directory = dirname(path)
+        if not exists(parent_directory):
+            makedirs(parent_directory)
+        _copy_to_path(request.body_file, path)
+        return Response(status=201, headers={'Location': urljoin(request.path_url, path)})
 
 
 def _copy_to_path(object, path):


### PR DESCRIPTION
Answer requests using the PUT request method. Assume the file being transferred is the whole body of the request and save it to the provided path just like it already happens for GET requests.

This is a follow up PR for galaxyproject/galaxy#20353.